### PR TITLE
Try changing `qunit` dependency to more up-to-date fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "qunit": "luckysw/node-qunit"
+    "qunit": "yomexzo/node-qunit"
   },
   "peerDependency": {
     "grunt": "~0.4.0"


### PR DESCRIPTION
I didn't look closely to see whether you had other important changes in `node-qunit`, but since @yomexzo's version seems to be working for me to get more recent QUnit API support, I'm suggesting this PR.

If you need to integrate your own changes to `node-qunit`, I suggest abandoning this PR and updating your own `node-qunit` to take into account the likes of @yomexzo's changes (as I demoed for you in another PR just now).
